### PR TITLE
fix reseting the state of the edit dialog

### DIFF
--- a/config/edit_action_dialog.cpp
+++ b/config/edit_action_dialog.cpp
@@ -209,14 +209,20 @@ bool EditActionDialog::load(qulonglong id)
         shortcut_SS->setText(QString());
         description_LE->clear();
         enabled_CB->setChecked(true);
-        command_RB->setChecked(false);
-        dbus_method_RB->setChecked(false);
         action_SW->setCurrentWidget(command_P);
         command_PTE->clear();
         service_LE->clear();
         path_LE->clear();
         interface_LE->clear();
         method_LE->clear();
+
+        // To disable all radio boxes, once one has been selected, we need to turn exclusivity off temporarily
+        command_RB->setAutoExclusive(false);
+        dbus_method_RB->setAutoExclusive(false);
+        command_RB->setChecked(false);
+        dbus_method_RB->setChecked(false);
+        command_RB->setAutoExclusive(true);
+        dbus_method_RB->setAutoExclusive(true);
 
         description_LE->setEnabled(true);
         command_RB->setEnabled(true);


### PR DESCRIPTION
This fixes the following bug:
* Open the globalkeys config
* Open the edit dialog (via `Add` or `Modify`, it doesn't matter), click one of the two radio boxes (Command vs. D-Bus) and close it again
* Press `Add`

Actual behavior:
* One of the two radio boxes is selected

Expected behavior:
* Neither of them is selected

The problem is that just doing `setChecked(false)` does not do anything if this part of an exclusive group. Turning that exclusivity off temporarily fixes this.