### PR TITLE
Fix untranslated string in French translation

### DIFF
--- a/config/translations/lxqt-config-globalkeyshortcuts_fr.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_fr.ts
@@ -63,7 +63,7 @@
     </message>
     <message>
         <location filename="../edit_action_dialog.ui" line="87"/>
-        <source>E&amp;nabled</source>
+        <source>&amp;Enabled</source>
         <translation>&amp;Activé</translation>
     </message>
     <message>


### PR DESCRIPTION
The string was missing because its source had been incorrectly edited.

Thanks!