### PR TITLE
lxqt-config-globalkeys: set Qt::AA_UseHighDpiPixmaps to true

### DIFF
--- a/config/main.cpp
+++ b/config/main.cpp
@@ -33,6 +33,7 @@
 int main(int argc, char *argv[])
 {
     LXQt::SingleApplication a(argc, argv);
+    a.setAttribute(Qt::AA_UseHighDpiPixmaps, true);
 
     QCommandLineParser parser;
     parser.setApplicationDescription(QStringLiteral("LXQt Config Globalkeys "));


### PR DESCRIPTION
refs lxde/lxqt/issues/916