### PR TITLE
Super keys

### DIFF
--- a/daemon/core.cpp
+++ b/daemon/core.cpp
@@ -1244,6 +1244,11 @@ void Core::run()
                             }
                         }
                     }
+                    if (keySyms)
+                    {
+                        XFree(keySyms);
+                        keySyms = nullptr;
+                    }
                     if (!ignoreKey)
                     {
                         IdsByShortcut::iterator idsByShortcut = mIdsByShortcut.find(shortcut);


### PR DESCRIPTION
This is the solution 1.2. which I described in issue lxde/lxqt#1259 on 3.12.2017.
This solution required the least changes in the source code.

You can merge the source code as it is. However, if you prefer a different name for the meta keys, e. g."meta-left" and "meta-right" instead of the X11 symbol names, then I can make the changes before merging.